### PR TITLE
Fix memory leaks and improve error handling

### DIFF
--- a/background/offscreen-manager.ts
+++ b/background/offscreen-manager.ts
@@ -22,6 +22,13 @@ export async function ensureOffscreenDocument(): Promise<void> {
     justification: 'Run Gemma 4 model inference via WebGPU',
   })
 
-  await creating
-  creating = null
+  try {
+    await creating
+  } catch (e) {
+    // If creation fails, make sure we reset the creating flag
+    // so subsequent calls can retry
+    throw e
+  } finally {
+    creating = null
+  }
 }

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -10,8 +10,15 @@ function getCountry(): string {
   const locale = navigator.language || 'en-US'
   const region = locale.split('-')[1]
   if (!region) return 'unknown'
-  const displayNames = new Intl.DisplayNames([locale], { type: 'region' })
-  return displayNames.of(region) ?? 'unknown'
+  try {
+    const displayNames = new Intl.DisplayNames([locale], { type: 'region' })
+    const country = displayNames.of(region)
+    return country ?? 'unknown'
+  } catch {
+    // Intl.DisplayNames may not be supported in all environments
+    // or the region code may be invalid
+    return 'unknown'
+  }
 }
 
 function buildSystemPrompt(pageContext?: string): string {
@@ -87,8 +94,10 @@ const modelHost = new GemmaModelHost((status, progress, error) => {
 })
 
 // Pending tool results keyed by requestId
-const pendingToolResults = new Map<string, (result: unknown) => void>()
+const pendingToolResults = new Map<string, { resolve: (result: unknown) => void, timeoutId: number }>()
 let requestIdCounter = 0
+
+const TOOL_EXECUTION_TIMEOUT = 30000 // 30 seconds
 
 function createToolExecutor(tabId: number) {
   return {
@@ -96,8 +105,14 @@ function createToolExecutor(tabId: number) {
       const requestId = `tool_${++requestIdCounter}`
       log.info('Executing tool:', call.name, JSON.stringify(call.arguments))
 
-      const resultPromise = new Promise<unknown>((resolve) => {
-        pendingToolResults.set(requestId, resolve)
+      const resultPromise = new Promise<unknown>((resolve, reject) => {
+        // Set up timeout to prevent hanging forever
+        const timeoutId = window.setTimeout(() => {
+          pendingToolResults.delete(requestId)
+          reject(new Error(`Tool ${call.name} execution timed out after ${TOOL_EXECUTION_TIMEOUT}ms`))
+        }, TOOL_EXECUTION_TIMEOUT)
+
+        pendingToolResults.set(requestId, { resolve, timeoutId })
       })
 
       chrome.runtime.sendMessage({
@@ -107,9 +122,14 @@ function createToolExecutor(tabId: number) {
         call,
       } satisfies Message)
 
-      const result = await resultPromise
-      log.debug('Tool result:', call.name, JSON.stringify(result).slice(0, 200))
-      return { name: call.name, result }
+      try {
+        const result = await resultPromise
+        log.debug('Tool result:', call.name, JSON.stringify(result).slice(0, 200))
+        return { name: call.name, result }
+      } catch (e) {
+        log.error('Tool execution failed:', call.name, e)
+        return { name: call.name, result: { error: e instanceof Error ? e.message : String(e) } }
+      }
     },
   }
 }
@@ -252,9 +272,10 @@ chrome.runtime.onMessage.addListener((message: Message) => {
 
     case 'tool:result': {
       log.debug('Tool result received:', message.requestId)
-      const resolve = pendingToolResults.get(message.requestId)
-      if (resolve) {
-        resolve(message.result)
+      const entry = pendingToolResults.get(message.requestId)
+      if (entry) {
+        clearTimeout(entry.timeoutId)
+        entry.resolve(message.result)
         pendingToolResults.delete(message.requestId)
       }
       break


### PR DESCRIPTION
## Summary

This PR addresses several reliability issues found in the codebase:

### 1. Memory leak in pendingToolResults Map

**Problem**: Tool execution promises had no timeout mechanism. If a tool execution failed or hung, the promise's resolve function would remain in the Map forever, causing a memory leak.

**Fix**: 
- Added 30-second timeout for tool execution
- Map now stores both resolve function and timeout ID
- Timeout properly cleans up the entry and rejects the promise
- Tool execution errors are caught and returned as proper error responses

### 2. Race condition in offscreen document creation

**Problem**: If creating the offscreen document failed in `background/offscreen-manager.ts`, the `creating` Promise was never reset, causing subsequent calls to hang indefinitely.

**Fix**: Wrapped the await in try-finally to ensure the `creating` flag is always reset, even if creation fails.

### 3. Intl.DisplayNames error handling

**Problem**: The `getCountry()` function in `entrypoints/offscreen/main.ts` didn't handle cases where `Intl.DisplayNames.of()` returns `undefined` or throws an exception for invalid region codes.

**Fix**: Added try-catch block and proper null/undefined handling.

## Testing

- Verified build succeeds: `pnpm build` completes successfully
- No TypeScript errors introduced
- Changes are minimal and focused on reliability improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)