### PR TITLE
Add keyboard hotkeys to control the chat overlay

### DIFF
--- a/content/chat-overlay.ts
+++ b/content/chat-overlay.ts
@@ -476,6 +476,10 @@ export class ChatOverlay {
     this.container.style.display = 'none'
   }
 
+  isVisible(): boolean {
+    return this.visible
+  }
+
   appendStream(text: string): void {
     this.hideTyping()
     this.streamText += text

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -130,6 +130,21 @@ export default defineContentScript({
       setGemDisabled(true)
     }
 
+    document.addEventListener('keydown', (e) => {
+      // Alt+G: toggle chat overlay
+      if (e.altKey && !e.ctrlKey && !e.metaKey && e.key === 'g') {
+        if (siteDisabled) return
+        e.preventDefault()
+        chat.toggle()
+        if (chat.isVisible()) safeSend({ type: 'chat:open' })
+        return
+      }
+      // Escape: close chat overlay
+      if (e.key === 'Escape' && !e.altKey && !e.ctrlKey && !e.metaKey && chat.isVisible()) {
+        chat.hide()
+      }
+    })
+
     browser.runtime.onMessage.addListener((message: Message) => {
       switch (message.type) {
         case 'agent:response':


### PR DESCRIPTION
Closes #8

## Summary

- **`Alt+G`** — toggle the chat overlay open/closed from anywhere on the page (respects the site-disabled state)
- **`Escape`** — close the overlay when it is visible

## Implementation

- Added `isVisible()` method to `ChatOverlay` so the document-level listener can check overlay state
- Registered a `keydown` listener on `document` in the content script after the overlay is mounted; `Alt+G` also fires `chat:open` to the background when opening, consistent with the icon click behaviour
- No new TypeScript errors introduced (pre-existing tsc errors in the repo are unrelated to this change)